### PR TITLE
:memo: Fix endless cats in quickstart-1

### DIFF
--- a/pages/guide/01-quickstart.md
+++ b/pages/guide/01-quickstart.md
@@ -342,8 +342,14 @@ counter is incremented and handle the response:
 pub fn update(model: Model, msg: Msg) -> #(Model, effect.Effect(Msg)) {
   case msg {
     UserIncrementedCount -> #(Model(..model, count: model.count + 1), get_cat())
-    UserDecrementedCount -> #(Model(..model, count: model.count - 1), effect.none())
-    ApiReturnedCat(Ok(cat)) -> #(Model(..model, cats: [cat, ..model.cats]), effect.none())
+    UserDecrementedCount -> #(
+      Model(cats: list.drop(model.cats, 1), count: model.count - 1),
+      effect.none(),
+    )
+    ApiReturnedCat(Ok(cat)) -> #(
+      Model(..model, cats: [cat, ..model.cats]),
+      effect.none(),
+    )
     ApiReturnedCat(Error(_)) -> #(model, effect.none())
   }
 }


### PR DESCRIPTION
I believe this is the way to go. Perhaps having the count be the length of the cats `List` makes more sense, but at least this prevents an explosion of cats. With that said, endless cats could definitely be called a feature instead of a bug 😂 